### PR TITLE
Java 11 source support and new option "useJdk9GeneratedAnnotation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Someday, when the attribute `age` is renamed it will break in the compilation or
 - debug (default: `false`): if `true` more information about annotation processing is written in the log;
 - suffix (default: `_INFO`): sets the suffix to name the generated code;
 - addGenerationDate (default: `false`): if `true` is added to the source its generation date;
-- onlyName (default: `false`): if `true` a simple String is used to represent a field.
+- onlyName (default: `false`): if `true` a simple String is used to represent a field;
+- useJdk9GeneratedAnnotation (default: `false`): if `true`, `javax.annotation.processing.Generated` will be used instead of `javax.annotation.Generated`.
 
 The options can be seen in `@SupportedOptions` [here](/src/main/java/io/github/mhagnumdw/beaninfogenerator/BeanMetaInfoProcessor.java#L39).
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <maven.release.plugin>2.5.3</maven.release.plugin>
-        <maven.compiler.plugin>3.6.0</maven.compiler.plugin>
-        <maven.source.plugin>3.0.1</maven.source.plugin>
-        <maven.javadoc.plugin>2.10.4</maven.javadoc.plugin>
+        <maven.compiler.plugin>3.8.1</maven.compiler.plugin>
+        <maven.source.plugin>3.2.0</maven.source.plugin>
+        <maven.javadoc.plugin>3.1.1</maven.javadoc.plugin>
         <cobertura.version>2.7</cobertura.version>
         <coveralls.version>3.1.0</coveralls.version>
     </properties>
@@ -54,6 +54,14 @@
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
             <version>1.9.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+        <!-- for javax.annotation.Generated in JDK >= 9 -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/src/main/java/io/github/mhagnumdw/beaninfogenerator/BeanMetaInfoProcessor.java
+++ b/src/main/java/io/github/mhagnumdw/beaninfogenerator/BeanMetaInfoProcessor.java
@@ -35,7 +35,7 @@ import io.github.mhagnumdw.beaninfogenerator.builder.ClassFactory;
     Context.ONLY_NAME
 })
 //@formatter:on
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 public class BeanMetaInfoProcessor extends AbstractProcessor {
 
     private static final boolean ALLOW_OTHER_PROCESSORS_TO_CLAIM_ANNOTATIONS = false;

--- a/src/main/java/io/github/mhagnumdw/beaninfogenerator/Context.java
+++ b/src/main/java/io/github/mhagnumdw/beaninfogenerator/Context.java
@@ -15,11 +15,14 @@ public final class Context {
     static final String SUFFIX = "suffix";
     static final String ADD_GENERATION_DATE = "addGenerationDate";
     static final String ONLY_NAME = "onlyName";
+    static final String USE_JDK9_GENERATED_ANNOTATION = "useJdk9GeneratedAnnotation";
+
 
     private boolean debug = false;
     private String suffix = "_INFO";
     private boolean addGenerationDate = false;
     private boolean onlyName = false;
+    private boolean useJdk9GeneratedAnnotation = false;
 
     /**
      * Constructor. Loads some options like debug, suffix, add generated date, only name etc.
@@ -48,6 +51,11 @@ public final class Context {
         tmp = pe.getOptions().get(ONLY_NAME);
         if (GeneralUtils.isNotBlank(tmp)) {
             setOnlyName(Boolean.parseBoolean(tmp));
+        }
+
+        tmp = pe.getOptions().get(USE_JDK9_GENERATED_ANNOTATION);
+        if (GeneralUtils.isNotBlank(tmp)) {
+            setUseJdk9GeneratedAnnotation(Boolean.parseBoolean(tmp));
         }
     }
 
@@ -81,6 +89,14 @@ public final class Context {
 
     public boolean isOnlyName() {
         return onlyName;
+    }
+
+    public boolean isUseJdk9GeneratedAnnotation() {
+        return useJdk9GeneratedAnnotation;
+    }
+
+    public void setUseJdk9GeneratedAnnotation(boolean useJdk9GeneratedAnnotation) {
+        this.useJdk9GeneratedAnnotation = useJdk9GeneratedAnnotation;
     }
 
     String supportedOptionsSummary() {

--- a/src/main/java/io/github/mhagnumdw/beaninfogenerator/builder/ClassBuilderAbstract.java
+++ b/src/main/java/io/github/mhagnumdw/beaninfogenerator/builder/ClassBuilderAbstract.java
@@ -1,12 +1,12 @@
 package io.github.mhagnumdw.beaninfogenerator.builder;
 
+import java.lang.annotation.Annotation;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.annotation.Generated;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
@@ -85,9 +85,12 @@ abstract class ClassBuilderAbstract implements ClassBuilder {
     }
 
     protected AnnotationSpec buildGeneratedAnnotationSpec(final String fcqnOriginalSource, final Context context) {
+        final Class<? extends Annotation> annotation = context.isUseJdk9GeneratedAnnotation() ?
+          javax.annotation.processing.Generated.class : javax.annotation.Generated.class;
+
         // @formatter:off
         final com.squareup.javapoet.AnnotationSpec.Builder generatedAnnotationSpecBuilder = AnnotationSpec
-                .builder(Generated.class)
+                .builder(annotation)
                 .addMember("value", "$S", BeanMetaInfoProcessor.class.getName())
                 .addMember("comments", "\"Only Name: $L, Class metadata information of: $L\"", context.isOnlyName(), fcqnOriginalSource);
         // @formatter:on

--- a/src/test/java/io/github/mhagnumdw/beaninfogenerator/BeanMetaInfoProcessorWithNoDefaultOptionsTest.java
+++ b/src/test/java/io/github/mhagnumdw/beaninfogenerator/BeanMetaInfoProcessorWithNoDefaultOptionsTest.java
@@ -46,4 +46,14 @@ public class BeanMetaInfoProcessorWithNoDefaultOptionsTest extends BeanMetaInfoP
         assertThat(compilation).generatedSourceFile(classData.generated).hasSourceEquivalentTo(classData.getExpectedJavaFileObject());
     }
 
+    @Test
+    public void testCompilationSuccess_WithJdk9GeneratedAnnotation() {
+        final String suffix = "_INFO_JDK9";
+        final ResourceData classData = new ResourceData("test/Class1WithAnnotation.java", suffix, true);
+        final Object[] compileOptions = { "-Asuffix=" + suffix, "-AuseJdk9GeneratedAnnotation=true" };
+        final Compilation compilation = TestUtils.compile(compileOptions, classData.getOriginalJavaFileObject());
+        assertThat(compilation).succeeded();
+        assertThat(compilation).generatedSourceFile(classData.generated).hasSourceEquivalentTo(classData.getExpectedJavaFileObject());
+    }
+
 }

--- a/src/test/resources/test/Class1WithAnnotation_INFO_JDK9.java
+++ b/src/test/resources/test/Class1WithAnnotation_INFO_JDK9.java
@@ -1,0 +1,22 @@
+package test;
+
+import io.github.mhagnumdw.beaninfogenerator.BeanMetaInfo;
+import javax.annotation.processing.Generated; // instead of javax.annotation.Generated
+
+//@formatter:off
+@Generated(
+    value = "io.github.mhagnumdw.beaninfogenerator.BeanMetaInfoProcessor",
+    comments = "Only Name: false, Class metadata information of: test.Class1WithAnnotation"
+)
+//@formatter:on
+public abstract class Class1WithAnnotation_INFO_JDK9 {
+    public static final BeanMetaInfo serialVersionUID = new BeanMetaInfo("serialVersionUID");
+
+    public static final BeanMetaInfo age = new BeanMetaInfo("age");
+
+    public static final BeanMetaInfo birthday = new BeanMetaInfo("birthday");
+
+    public static final BeanMetaInfo name = new BeanMetaInfo("name");
+
+    public static final BeanMetaInfo classTwo = new BeanMetaInfo("classTwo");
+}


### PR DESCRIPTION
First of all, this PR adds support for Java 11 sources by setting `@SupportedSourceVersion(SourceVersion.RELEASE_11)`.

Also, it adresses the issue that `javax.annotation.Generated` has been removed from Java 9 in favor of `javax.annotation.processing.Generated`. The new option "useJdk9GeneratedAnnotation" (name is up for discussion) causes the newer annotation to be emitted (default is false to have backwards compatibility).